### PR TITLE
Fix for Deadlock and Transport Drones gears conflict

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,6 +1,6 @@
 local GIR = require('prototypes/functions/functions')
 
-GIR.global_item_replacer("iron-gear-wheel","small-parts-01",{"iron-gear-wheel","small-parts-01","casting-gear"})
+GIR.global_item_replacer("iron-gear-wheel","small-parts-01",{"iron-gear-wheel","small-parts-01","casting-gear", "deadlock-stacks-stack-iron-gear-wheel", "deadlock-stacks-unstack-iron-gear-wheel", "ungine-unit"})
 
 --RECIPES UPDATES
 --hot air blacklist

--- a/data.lua
+++ b/data.lua
@@ -264,7 +264,7 @@ table.insert(data.raw['fluid-turret']['flamethrower-turret'].attack_parameters.f
 end
 
 --(( OTHERS ))--
-GIR.global_item_replacer("iron-gear-wheel","small-parts-01",{"iron-gear-wheel","small-parts-01","casting-gear"})
+GIR.global_item_replacer("iron-gear-wheel","small-parts-01",{"iron-gear-wheel","small-parts-01","casting-gear", "deadlock-stacks-stack-iron-gear-wheel", "deadlock-stacks-unstack-iron-gear-wheel", "ungine-unit"})
 
 --(( Shortcut keys ))--
 local recipeselect=


### PR DESCRIPTION
Added deadlocks compact gears and noengine from transport drones to the blacklist when replacing gears with small-parts.
