### PR TITLE
Miners no longer take simik related modules

### DIFF
--- a/prototypes/buildings/bitumen-seep-mk01.lua
+++ b/prototypes/buildings/bitumen-seep-mk01.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/bitumen-seep-mk02.lua
+++ b/prototypes/buildings/bitumen-seep-mk02.lua
@@ -48,7 +48,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/bitumen-seep-mk03.lua
+++ b/prototypes/buildings/bitumen-seep-mk03.lua
@@ -47,7 +47,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/bitumen-seep-mk04.lua
+++ b/prototypes/buildings/bitumen-seep-mk04.lua
@@ -40,7 +40,7 @@ ENTITY{
     collision_box = {{-5.4, -5.4}, {5.4, 5.4}},
     selection_box = {{-5.5, -5.5}, {5.5, 5.5}},
     module_specification = {module_slots = 1},
-    allowed_effects = {'consumption', 'speed', 'productivity', 'pollution'},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {type = 'electric', usage_priority = 'secondary-input', emissions_per_minute = 20},
     energy_usage = '1000kW',
     mining_speed = 3,

--- a/prototypes/buildings/natural-gas-extractor-mk01.lua
+++ b/prototypes/buildings/natural-gas-extractor-mk01.lua
@@ -68,6 +68,7 @@ ENTITY {
     {
       module_slots = 2
     },
+    allowed_effects = {"consumption", "speed", "productivity"},
     radius_visualisation_picture =
     {
       filename = "__base__/graphics/entity/pumpjack/pumpjack-radius-visualization.png",

--- a/prototypes/buildings/natural-gas-extractor-mk02.lua
+++ b/prototypes/buildings/natural-gas-extractor-mk02.lua
@@ -68,6 +68,7 @@ ENTITY {
     {
       module_slots = 2
     },
+    allowed_effects = {"consumption", "speed", "productivity"},
     radius_visualisation_picture =
     {
       filename = "__base__/graphics/entity/pumpjack/pumpjack-radius-visualization.png",

--- a/prototypes/buildings/natural-gas-extractor-mk03.lua
+++ b/prototypes/buildings/natural-gas-extractor-mk03.lua
@@ -68,6 +68,7 @@ ENTITY {
     {
       module_slots = 2
     },
+    allowed_effects = {"consumption", "speed", "productivity"},
     radius_visualisation_picture =
     {
       filename = "__base__/graphics/entity/pumpjack/pumpjack-radius-visualization.png",

--- a/prototypes/buildings/natural-gas-extractor-mk04.lua
+++ b/prototypes/buildings/natural-gas-extractor-mk04.lua
@@ -68,6 +68,7 @@ ENTITY {
     {
       module_slots = 2
     },
+    allowed_effects = {"consumption", "speed", "productivity"},
     radius_visualisation_picture =
     {
       filename = "__base__/graphics/entity/pumpjack/pumpjack-radius-visualization.png",

--- a/prototypes/buildings/natural-gas-seep-mk01.lua
+++ b/prototypes/buildings/natural-gas-seep-mk01.lua
@@ -54,6 +54,7 @@ ENTITY {
     {
       module_slots = 2
     },
+    allowed_effects = {"consumption", "speed", "productivity"},
     radius_visualisation_picture =
     {
       filename = "__base__/graphics/entity/pumpjack/pumpjack-radius-visualization.png",

--- a/prototypes/buildings/natural-gas-seep-mk02.lua
+++ b/prototypes/buildings/natural-gas-seep-mk02.lua
@@ -49,6 +49,7 @@ ENTITY{
     resource_searching_radius = 0.49,
     vector_to_place_result = {0, 0},
     module_specification = {module_slots = 2},
+    allowed_effects = {"consumption", "speed", "productivity"},
     radius_visualisation_picture = {
         filename = '__base__/graphics/entity/pumpjack/pumpjack-radius-visualization.png',
         width = 12,

--- a/prototypes/buildings/natural-gas-seep-mk03.lua
+++ b/prototypes/buildings/natural-gas-seep-mk03.lua
@@ -57,6 +57,7 @@ ENTITY {
     {
       module_slots = 2
     },
+    allowed_effects = {"consumption", "speed", "productivity"},
     radius_visualisation_picture =
     {
       filename = "__base__/graphics/entity/pumpjack/pumpjack-radius-visualization.png",

--- a/prototypes/buildings/natural-gas-seep-mk04.lua
+++ b/prototypes/buildings/natural-gas-seep-mk04.lua
@@ -54,6 +54,7 @@ ENTITY {
     {
       module_slots = 2
     },
+    allowed_effects = {"consumption", "speed", "productivity"},
     radius_visualisation_picture =
     {
       filename = "__base__/graphics/entity/pumpjack/pumpjack-radius-visualization.png",

--- a/prototypes/buildings/oil-derrick-mk01.lua
+++ b/prototypes/buildings/oil-derrick-mk01.lua
@@ -48,7 +48,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/oil-derrick-mk02.lua
+++ b/prototypes/buildings/oil-derrick-mk02.lua
@@ -48,7 +48,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/oil-derrick-mk03.lua
+++ b/prototypes/buildings/oil-derrick-mk03.lua
@@ -48,7 +48,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/oil-derrick-mk04.lua
+++ b/prototypes/buildings/oil-derrick-mk04.lua
@@ -46,7 +46,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/oil-sand-extractor-mk01.lua
+++ b/prototypes/buildings/oil-sand-extractor-mk01.lua
@@ -44,7 +44,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 1,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/oil-sand-extractor-mk02.lua
+++ b/prototypes/buildings/oil-sand-extractor-mk02.lua
@@ -46,7 +46,7 @@ ENTITY {
     module_specification = {
         module_slots = 2
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 2,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/oil-sand-extractor-mk03.lua
+++ b/prototypes/buildings/oil-sand-extractor-mk03.lua
@@ -43,7 +43,7 @@ ENTITY {
     module_specification = {
         module_slots = 3
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 3,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/oil-sand-extractor-mk04.lua
+++ b/prototypes/buildings/oil-sand-extractor-mk04.lua
@@ -42,7 +42,7 @@ ENTITY {
     module_specification = {
         module_slots = 4
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 4,
     energy_source = {
         type = "electric",

--- a/prototypes/buildings/sulfur-mine.lua
+++ b/prototypes/buildings/sulfur-mine.lua
@@ -44,7 +44,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 5,
     energy_source =
     {

--- a/prototypes/buildings/tar-extractor-mk01.lua
+++ b/prototypes/buildings/tar-extractor-mk01.lua
@@ -47,7 +47,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/tar-extractor-mk02.lua
+++ b/prototypes/buildings/tar-extractor-mk02.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/tar-extractor-mk03.lua
+++ b/prototypes/buildings/tar-extractor-mk03.lua
@@ -47,7 +47,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/tar-extractor-mk04.lua
+++ b/prototypes/buildings/tar-extractor-mk04.lua
@@ -47,7 +47,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/tar-seep-mk01.lua
+++ b/prototypes/buildings/tar-seep-mk01.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/tar-seep-mk02.lua
+++ b/prototypes/buildings/tar-seep-mk02.lua
@@ -44,7 +44,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/tar-seep-mk03.lua
+++ b/prototypes/buildings/tar-seep-mk03.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",

--- a/prototypes/buildings/tar-seep-mk04.lua
+++ b/prototypes/buildings/tar-seep-mk04.lua
@@ -44,7 +44,7 @@ ENTITY {
     module_specification = {
         module_slots = 1
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     energy_source = {
         type = "electric",
         usage_priority = "secondary-input",


### PR DESCRIPTION
This is done by making these modules increase pollution output, and forbidding pollution modules in these miners.