### PR TITLE
Oil Sand Extractor circuit connections

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Date: ?
     - added grease table mk04
     - deleted empty, unused techs. heavy oil mk3 & petroleum gas processing mk3
     - fixed that kevlar mk02 did not allow productivity when kevlar mk01 allowed it.
+    - added circuit connectivity to Oil Sand Extractors (credit: JStMorgan)
 ---------------------------------------------------------------------------------------------------
 Version: 2.1.9
 Date: 2023-7-25

--- a/data.lua
+++ b/data.lua
@@ -6,6 +6,9 @@ require("prototypes/recipe-categories")
 
 require('prototypes/items/items')
 
+-- (( Circuit Connector Definitions )) --
+require('prototypes/circuit-connector-definitions')
+-- ))
 
 --(( RESOURCES ))--
 require("prototypes.ores.oil-sand")

--- a/prototypes/buildings/oil-sand-extractor-mk01.lua
+++ b/prototypes/buildings/oil-sand-extractor-mk01.lua
@@ -60,6 +60,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["oil-sand-extractor-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["oil-sand-extractor-mkxx"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/oil-sand-extractor-mk02.lua
+++ b/prototypes/buildings/oil-sand-extractor-mk02.lua
@@ -62,6 +62,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["oil-sand-extractor-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["oil-sand-extractor-mkxx"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/oil-sand-extractor-mk03.lua
+++ b/prototypes/buildings/oil-sand-extractor-mk03.lua
@@ -59,6 +59,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["oil-sand-extractor-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["oil-sand-extractor-mkxx"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/buildings/oil-sand-extractor-mk04.lua
+++ b/prototypes/buildings/oil-sand-extractor-mk04.lua
@@ -58,6 +58,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["oil-sand-extractor-mkxx"].points,
+    circuit_connector_sprites = circuit_connector_definitions["oil-sand-extractor-mkxx"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/circuit-connector-definitions.lua
+++ b/prototypes/circuit-connector-definitions.lua
@@ -1,0 +1,13 @@
+-- Holds circuit connection definitions for PyPH entities.
+-- variation counts from 0 (Python-like).
+
+circuit_connector_definitions["oil-sand-extractor-mkxx"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 10, main_offset = util.by_pixel(105, -150), shadow_offset = util.by_pixel(99, -138), show_shadow = false },
+    { variation = 10, main_offset = util.by_pixel(105, -150), shadow_offset = util.by_pixel(99, -138), show_shadow = false },
+    { variation = 10, main_offset = util.by_pixel(105, -150), shadow_offset = util.by_pixel(99, -138), show_shadow = false },
+    { variation = 10, main_offset = util.by_pixel(105, -150), shadow_offset = util.by_pixel(99, -138), show_shadow = false }
+  }
+)


### PR DESCRIPTION
Another set of miners have been given circuit connectivity! This PR updates the Oil Sand Extractor Mks. I-IV with this feature.