### PR TITLE
Added Sulphur Mine circuit connectivity

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version: 2.1.16
+Date: When it's done
+  Changes:
+    - Added circuit connectivity to Sulfur Mine (credit: JStMorgan)
 ---------------------------------------------------------------------------------------------------
 Version: 2.1.15
 Date: 2024-3-24

--- a/prototypes/buildings/sulfur-mine.lua
+++ b/prototypes/buildings/sulfur-mine.lua
@@ -79,6 +79,9 @@ ENTITY {
         width = 12,
         height = 12
     },
+    circuit_wire_connection_points = circuit_connector_definitions["sulfur-mine"].points,
+    circuit_connector_sprites = circuit_connector_definitions["sulfur-mine"].sprites,
+    circuit_wire_max_distance = default_circuit_wire_max_distance,
     animations = {
         layers = {
             {

--- a/prototypes/circuit-connector-definitions.lua
+++ b/prototypes/circuit-connector-definitions.lua
@@ -67,6 +67,17 @@ circuit_connector_definitions["oil-sand-extractor-mkxx"] = circuit_connector_def
   }
 )
 
+circuit_connector_definitions["sulfur-mine"] = circuit_connector_definitions.create
+(
+  universal_connector_template,
+  {--Directions are up, right, down, left.
+    { variation = 2, main_offset = util.by_pixel(90, 72), shadow_offset = util.by_pixel(84, 60), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(90, 72), shadow_offset = util.by_pixel(84, 60), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(90, 72), shadow_offset = util.by_pixel(84, 60), show_shadow = false },
+    { variation = 2, main_offset = util.by_pixel(90, 72), shadow_offset = util.by_pixel(84, 60), show_shadow = false }
+  }
+)
+
 circuit_connector_definitions["tar-extractor-mkxx"] = circuit_connector_definitions.create
 (
   universal_connector_template,


### PR DESCRIPTION
I'm back into my pY's map and find myself needing to add circuit monitoring to a Sulphur Mine, so here's the PR to enable that! Partly addresses pyanodon/pybugreports#415 .
This PR branches from and currently points to the Frozen branch in the master pY PH repo to avoid clashing with any pY SE changes that might be cooking in the meantime.