### PR TITLE
[HM] Hydrogen void unlocked in Automation science needs py1 #1066

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version: 3.0.20
+Date: ????-??-??
+  Changes:
+    - Anthracene + Hydrogen -> Gasoline recipe can now be used in automation science. Resolves https://github.com/pyanodon/pybugreports/issues/1066
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.19
 Date: 2025-07-20

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -15,8 +15,10 @@ soot-separation=Soot separation
 tar-refining-tops=Tar refining tops
 tar-refining=Tar refining bottoms
 drilling-fluids=Bitumen seep extraction
+anthracene-gasoline-hydrogenation=Gasoline (DEPRECIATED)
 
 [recipe-description]
+anthracene-gasoline-hydrogenation=THIS IS A DEPRECIATED RECIPE DO NOT USE
 
 [item-group-name]
 py-petroleum-handling=Py Petroleum Handling

--- a/prototypes/buildings/upgrader-mk01.lua
+++ b/prototypes/buildings/upgrader-mk01.lua
@@ -13,7 +13,7 @@ RECIPE {
     results = {
         {type = "item", name = "upgrader-mk01", amount = 1}
     }
-}:add_unlock("syngas")
+}:add_unlock("oil-machines-mk01")
 
 ITEM {
     type = "item",

--- a/prototypes/buildings/upgrader-mk01.lua
+++ b/prototypes/buildings/upgrader-mk01.lua
@@ -13,7 +13,7 @@ RECIPE {
     results = {
         {type = "item", name = "upgrader-mk01", amount = 1}
     }
-}:add_unlock("oil-machines-mk01")
+}:add_unlock("syngas")
 
 ITEM {
     type = "item",

--- a/prototypes/recipes/gasoline-recipes.lua
+++ b/prototypes/recipes/gasoline-recipes.lua
@@ -3,6 +3,25 @@ RECIPE {
     name = "anthracene-gasoline-hydrogenation",
     category = "upgrader",
     enabled = false,
+	hidden = true,
+    energy_required = 4,
+    ingredients = {
+        {type = "fluid", name = "anthracene-oil", amount = 50},
+        {type = "fluid", name = "hydrogen",       amount = 50}
+    },
+    results = {
+        {type = "fluid", name = "gasoline", amount = 25},
+    },
+    main_product = "gasoline",
+    subgroup = "py-petroleum-handling-recipes",
+    order = "a"
+}:add_unlock("syngas")
+
+RECIPE {
+    type = "recipe",
+    name = "anthracene-gasoline-hydrogenation-new",
+    category = "gasifier",
+    enabled = false,
     energy_required = 4,
     ingredients = {
         {type = "fluid", name = "anthracene-oil", amount = 50},


### PR DESCRIPTION
Ionic Upgrader now unlocked at oil machines 01. Gasoline recipe hidden. Identical gasoline recipe crafted in the gasifier added. Added depreciation message for original recipe. Updated changelog.txt

Only English locale has been updated for depreciation message, let me know if there is a procedure that needs to be done to update other locale files.